### PR TITLE
41 exclude 0LOS assessment beds when calculating ward beds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/nhp/capacity_conversion/ip_wards.py
+++ b/src/nhp/capacity_conversion/ip_wards.py
@@ -145,8 +145,16 @@ def calculate_ward_beddays(functional_areas_summarised, bedday_pools):
             assessment_beddays = bedday_pools.get(
                 f_a + "_assessment_beddays", {"p10": 0, "mean": 0, "p90": 0}
             )[value]  # elective activity will not have any assesssment beddays
+            _0los_assessment_beddays = bedday_pools.get(
+                f_a + "_0los_assessment_beddays", {"p10": 0, "mean": 0, "p90": 0}
+            )[value]
             cc_beddays = bedday_pools[f_a + "_cc_beddays"][value]
-            ward_beddays = total_adjusted_beddays - assessment_beddays - cc_beddays
+            ward_beddays = (
+                total_adjusted_beddays
+                - assessment_beddays
+                - _0los_assessment_beddays
+                - cc_beddays
+            )
             results[value] = ward_beddays
         ip_ward_beddays_dict[f_a + "_ward_beddays"] = results
     return ip_ward_beddays_dict

--- a/tests/unit/test_ip_wards.py
+++ b/tests/unit/test_ip_wards.py
@@ -137,7 +137,6 @@ def test_convert_ip_beddays_to_beds():
 
 
 def test_calculate_ward_beddays():
-    # arrange
     functional_areas = [
         "adult_elective_medical",
         "adult_nonelective_medical",
@@ -148,34 +147,46 @@ def test_calculate_ward_beddays():
         "paediatric_elective_surgical",
         "paediatric_nonelective_surgical",
     ]
-    values_dict = {"p10": 100, "mean": 100, "p90": 100}
+    total_beddays = {"p10": 1000, "mean": 1000, "p90": 1000}
+    los0_beddays = {"p10": 200, "mean": 200, "p90": 200}
+    cc_beddays = {"p10": 30, "mean": 30, "p90": 30}  # ~3%
+    assessment_bd = {"p10": 100, "mean": 100, "p90": 100}
+    assessment_0los = {"p10": 20, "mean": 20, "p90": 20}
+
     functional_areas_summarised = {
-        f_a + "_beddays": values_dict for f_a in functional_areas
+        f_a + "_beddays": total_beddays for f_a in functional_areas
     }
-    # 0los first
-    bedday_pools = {f_a + "_0los_beddays": values_dict for f_a in functional_areas}
-    # assessment first
-    assessment = {
-        f_a + "_assessment_beddays": values_dict
-        for f_a in functional_areas
-        if "nonelective" in f_a
-    }
-    bedday_pools.update(assessment)
-    # add critical care
-    critical_care = {f_a + "_cc_beddays": values_dict for f_a in functional_areas}
-    bedday_pools.update(critical_care)
-    results_dict_nonelective = {"p10": 0, "mean": 0, "p90": 0}
-    results_dict_elective = {"p10": 100, "mean": 100, "p90": 100}
-    expected = {
-        f_a + "_ward_beddays": (
-            results_dict_nonelective if "nonelective" in f_a else results_dict_elective
-        )
-        for f_a in functional_areas
-    }
-    # act
-    actual = calculate_ward_beddays(functional_areas_summarised, bedday_pools)
-    # assert
-    assert actual == expected
+
+    bedday_pools = {}
+    bedday_pools.update(
+        {f_a + "_0los_beddays": los0_beddays for f_a in functional_areas}
+    )
+    bedday_pools.update({f_a + "_cc_beddays": cc_beddays for f_a in functional_areas})
+    bedday_pools.update(
+        {
+            f_a + "_assessment_beddays": assessment_bd
+            for f_a in functional_areas
+            if "nonelective" in f_a
+        }
+    )
+    bedday_pools.update(
+        {
+            f_a + "_0los_assessment_beddays": assessment_0los
+            for f_a in functional_areas
+            if "nonelective" in f_a
+        }
+    )
+
+    # nonelective: (1000 + 200) - 30 - 100 - 20 = 1050
+    # elective:    (1000 + 200) - 30            = 1170
+    expected_nonelective = {"p10": 1050.0, "mean": 1050.0, "p90": 1050.0}
+    expected_elective = {"p10": 1170.0, "mean": 1170.0, "p90": 1170.0}
+
+    result = calculate_ward_beddays(functional_areas_summarised, bedday_pools)
+
+    for f_a in functional_areas:
+        expected = expected_nonelective if "nonelective" in f_a else expected_elective
+        assert result[f_a + "_ward_beddays"] == pytest.approx(expected)
 
 
 def test_calculate_separate_bedday_pools(mocker):


### PR DESCRIPTION
Closes #41 

**Problem:**
`calculate_ward_beddays()` subtracted `_assessment_beddays` from the total bedday pool, but failed to also subtract `_0los_assessment_beddays`. This caused 0LOS assessment beddays to be counted twice, once as assessment beds and again in the ward bed total, resulting in ward bed counts being overstated.

**Changes:**
- `ip_wards.py` - `calculate_ward_beddays()`: added subtraction of `f_a + "_0los_assessment_beddays"` (defaulting to zero if absent) alongside the existing `_assessment_beddays` subtraction.
- `test_ip_wards.py` - `test_calculate_ward_beddays()`: added `_0los_assessment_beddays` entries to `bedday_pools` to reflect what `calculate_separate_bedday_pools` actually produces; updated expected values to account for both assessment pools being subtracted.   
Test values were chosen to be distinct and positive so that any missing or duplicated subtraction produces a clearly incorrect result, while ensuring all intermediate and final bedday totals remain positive and realistic.

**Repository configuration:**
- Added a `.gitattributes` file with `* text=auto` to standardise text file handling across OSs.