### PR TITLE
feat: add suppressed baseline activity to Excel output

### DIFF
--- a/src/nhp/capacity_conversion/main.py
+++ b/src/nhp/capacity_conversion/main.py
@@ -18,6 +18,7 @@ from nhp.capacity_conversion.ip_wards import (
 from nhp.capacity_conversion.op import calculate_op_capacity
 from nhp.capacity_conversion.utils import (
     create_aggregations_path,
+    get_baseline_activity,
     load_aggregations,
     load_assumptions,
     load_metadata_from_ats,
@@ -77,6 +78,7 @@ def main():
     data_to_save["op_functional_areas"] = pd.DataFrame.from_dict(
         functional_areas_summarised, orient="index"
     )
+    data_to_save["op_baseline"] = get_baseline_activity(op_aggregations)
     op_capacity_df = calculate_op_capacity(functional_areas_summarised, assumptions)
     data_to_save["op_capacity"] = op_capacity_df
     # AAE
@@ -88,6 +90,7 @@ def main():
     data_to_save["aae_functional_areas"] = pd.DataFrame.from_dict(
         functional_areas_summarised, orient="index"
     )
+    data_to_save["aae_baseline"] = get_baseline_activity(aae_aggregations)
     aae_capacity_df = calculate_aae_capacity(functional_areas_summarised, assumptions)
     data_to_save["aae_capacity"] = aae_capacity_df
     # ip_daycase
@@ -101,6 +104,7 @@ def main():
     data_to_save["ip_daycase_functional_areas"] = pd.DataFrame.from_dict(
         functional_areas_summarised, orient="index"
     )
+    data_to_save["ip_daycase_baseline"] = get_baseline_activity(ip_daycase_aggregations)
     ip_daycase_capacity_df = calculate_ip_daycase_capacity(
         functional_areas_summarised, assumptions
     )
@@ -117,6 +121,7 @@ def main():
     data_to_save["ip_wards_functional_areas"] = pd.DataFrame.from_dict(
         functional_areas_summarised, orient="index"
     )
+    data_to_save["ip_wards_baseline"] = get_baseline_activity(ip_wards_aggregations)
     bedday_pools = calculate_separate_bedday_pools(
         functional_areas_summarised, assumptions
     )

--- a/src/nhp/capacity_conversion/utils.py
+++ b/src/nhp/capacity_conversion/utils.py
@@ -1,15 +1,45 @@
-import pandas as pd
-from nhpy.utils import get_logger
-from nhpy.az import connect_to_container, load_parquet_file
-from azure.data.tables import TableClient
-from azure.identity import DefaultAzureCredential
-from azure.core.exceptions import ResourceNotFoundError
-from openpyxl import Workbook
-from openpyxl.utils.dataframe import dataframe_to_rows
-from dotenv import load_dotenv
 import os
 
+import pandas as pd
+from azure.core.exceptions import ResourceNotFoundError
+from azure.data.tables import TableClient
+from azure.identity import DefaultAzureCredential
+from dotenv import load_dotenv
+from nhpy.az import connect_to_container, load_parquet_file
+from nhpy.utils import get_logger
+from openpyxl import Workbook
+from openpyxl.utils.dataframe import dataframe_to_rows
+
 logger = get_logger()
+
+# Suppression methodology follows NHS England HES standard:
+# https://digital.nhs.uk/data-and-information/publications/statistical/
+# hospital-admitted-patient-care-activity/supporting-information#suppression-methodology
+SUPPRESSION_THRESHOLD = 7  # suppress counts 1–7; round all others to nearest 5
+
+
+def get_baseline_activity(aggregations: pd.DataFrame) -> pd.Series:
+    """Extract baseline (model run 0) total activity per functional area.
+
+    Applies NHS England HES suppression rules:
+    - Values 1–7 are replaced with None (displayed as blank in Excel)
+    - All other non-zero values are rounded to the nearest 5
+
+    Args:
+        aggregations (pd.DataFrame): Raw aggregations with model_run index,
+            grouping and total columns
+
+    Returns:
+        pd.Series: Baseline activity per grouping, suppressed and rounded
+    """
+    baseline = aggregations[aggregations.index == 0].groupby("grouping")["total"].sum()
+
+    def _suppress_and_round(x: float) -> float | None:
+        if 1 <= x <= SUPPRESSION_THRESHOLD:
+            return None
+        return round(x / 5) * 5
+
+    return baseline.map(_suppress_and_round)
 
 
 def calculate_prediction_intervals_and_mean(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -136,15 +136,20 @@ def test_main(mocker):
         "metadata",
         "assumptions",
         "op_functional_areas",
+        "op_baseline",
         "op_capacity",
         "aae_functional_areas",
+        "aae_baseline",
         "aae_capacity",
         "ip_daycase_functional_areas",
+        "ip_daycase_baseline",
         "ip_daycase_capacity",
         "ip_wards_functional_areas",
+        "ip_wards_baseline",
         "calculated_bedday_pools",
         "ip_wards_capacity",
     ]
+
     assert_series_equal(
         mock_data_to_save["metadata"],
         pd.Series(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,17 +1,35 @@
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
 from azure.core.exceptions import ResourceNotFoundError
+from pandas.testing import assert_frame_equal
+
 from nhp.capacity_conversion.utils import (
     calculate_prediction_intervals_and_mean,
-    load_assumptions,
-    save_results_to_excel,
-    load_metadata_from_ats,
     create_aggregations_path,
-    validate_required_env_vars,
+    get_baseline_activity,
     load_aggregations,
+    load_assumptions,
+    load_metadata_from_ats,
+    save_results_to_excel,
     summarise_functional_areas,
+    validate_required_env_vars,
 )
+
+
+def test_get_baseline_activity():
+    aggregations = pd.DataFrame(
+        {
+            "grouping": ["a", "b", "c"] * 3,
+            "model_run": [0] * 3 + [1] * 3 + [2] * 3,
+            "total": [3, 10, 100] * 3,
+        }
+    ).set_index("model_run")
+
+    result = get_baseline_activity(aggregations)
+
+    assert pd.isna(result["a"])  # 3 is suppressed (1–7)
+    assert result["b"] == 10  # 10 rounds to 10
+    assert result["c"] == 100  # 100 rounds to 100
 
 
 def test_calculate_prediction_intervals_and_mean():


### PR DESCRIPTION
Closes #40 

Adds baseline (model run 0) activity figures for each functional area to the Excel output, so users can sense-check projections against current activity levels.  

<img width="2151" height="77" alt="Screenshot 2026-05-08 144505" src="https://github.com/user-attachments/assets/f7b8d060-8a5b-4c94-8cfb-d46a4fcbc27c" />  


**Changes:**
- New `get_baseline_activity()` in `utils.py` extracts run 0 totals per functional area
- Four new sheets added to the Excel output: `op_baseline`, `aae_baseline`, `ip_daycase_baseline`, `ip_wards_baseline`, each placed alongside the corresponding `_functional_areas` sheet
- New constant `SUPPRESSION_THRESHOLD = 7` in `utils.py`

**Suppression approach:**  
NHS England HES suppression rules applied ([source](https://digital.nhs.uk/data-and-information/publications/statistical/hospital-admitted-patient-care-activity/supporting-information)):
- Values 1–7 → `None` (blank cell in Excel)
- All other values → rounded to nearest 5

Second-level suppression is not required here: the output is a single flat set of functional area totals with no organisational hierarchy from which a suppressed value could be back-calculated.

**Tests:** 
- `test_utils.py` and `test_main.py` updated accordingly.